### PR TITLE
[FIX] Change value access for userId

### DIFF
--- a/frontend/sales-agent-crew/src/components/SearchSection.vue
+++ b/frontend/sales-agent-crew/src/components/SearchSection.vue
@@ -129,9 +129,9 @@ const { userId } = useAuth()
 
 async function loadKeys() {
   try {
-    const encryptedSambanovaKey = localStorage.getItem(`sambanova_key_${userId}`)
-    const encryptedExaKey = localStorage.getItem(`exa_key_${userId}`)
-    const encryptedSerperKey = localStorage.getItem(`serper_key_${userId}`)
+    const encryptedSambanovaKey = localStorage.getItem(`sambanova_key_${userId.value}`)
+    const encryptedExaKey = localStorage.getItem(`exa_key_${userId.value}`)
+    const encryptedSerperKey = localStorage.getItem(`serper_key_${userId.value}`)
 
     if (encryptedSambanovaKey) {
       sambanovaKey.value = await decryptKey(encryptedSambanovaKey)
@@ -192,7 +192,7 @@ async function performSearch() {
           'x-sambanova-key': sambanovaKey.value || '',
           // Make sure to pass runId here if your backend expects it for "route" 
           // (But typically only needed on "execute"... optional)
-          'x-user-id': userId || '',
+          'x-user-id': userId.value || '',
           'x-run-id': props.runId || ''
         }
       }

--- a/frontend/sales-agent-crew/src/components/SettingsModal.vue
+++ b/frontend/sales-agent-crew/src/components/SettingsModal.vue
@@ -223,9 +223,9 @@ onMounted(async () => {
 
 const loadKeys = async () => {
   try {
-    const savedSambanovaKey = localStorage.getItem(`sambanova_key_${userId}`)
-    const savedExaKey = localStorage.getItem(`exa_key_${userId}`)
-    const savedSerperKey = localStorage.getItem(`serper_key_${userId}`)
+    const savedSambanovaKey = localStorage.getItem(`sambanova_key_${userId.value}`)
+    const savedExaKey = localStorage.getItem(`exa_key_${userId.value}`)
+    const savedSerperKey = localStorage.getItem(`serper_key_${userId.value}`)
 
     sambanovaKey.value = savedSambanovaKey
       ? await decryptKey(savedSambanovaKey)
@@ -250,7 +250,7 @@ const saveSambanovaKey = async () => {
       return
     }
     const encryptedKey = await encryptKey(sambanovaKey.value)
-    localStorage.setItem(`sambanova_key_${userId}`, encryptedKey)
+    localStorage.setItem(`sambanova_key_${userId.value}`, encryptedKey)
     successMessage.value = 'SambaNova API key saved successfully!'
     emit('keysUpdated')
   } catch (error) {
@@ -262,7 +262,7 @@ const saveSambanovaKey = async () => {
 }
 
 const clearSambanovaKey = () => {
-  localStorage.removeItem(`sambanova_key_${userId}`)
+  localStorage.removeItem(`sambanova_key_${userId.value}`)
   sambanovaKey.value = ''
   successMessage.value = 'SambaNova API key cleared successfully!'
   emit('keysUpdated')
@@ -276,7 +276,7 @@ const saveExaKey = async () => {
       return
     }
     const encryptedKey = await encryptKey(exaKey.value)
-    localStorage.setItem(`exa_key_${userId}`, encryptedKey)
+    localStorage.setItem(`exa_key_${userId.value}`, encryptedKey)
     successMessage.value = 'Exa API key saved successfully!'
     emit('keysUpdated')
   } catch (error) {
@@ -288,7 +288,7 @@ const saveExaKey = async () => {
 }
 
 const clearExaKey = () => {
-  localStorage.removeItem(`exa_key_${userId}`)
+  localStorage.removeItem(`exa_key_${userId.value}`)
   exaKey.value = ''
   successMessage.value = 'Exa API key cleared successfully!'
   emit('keysUpdated')
@@ -302,7 +302,7 @@ const saveSerperKey = async () => {
       return
     }
     const encryptedKey = await encryptKey(serperKey.value)
-    localStorage.setItem(`serper_key_${userId}`, encryptedKey)
+    localStorage.setItem(`serper_key_${userId.value}`, encryptedKey)
     successMessage.value = 'Serper API key saved successfully!'
     emit('keysUpdated')
   } catch (error) {
@@ -314,7 +314,7 @@ const saveSerperKey = async () => {
 }
 
 const clearSerperKey = () => {
-  localStorage.removeItem(`serper_key_${userId}`)
+  localStorage.removeItem(`serper_key_${userId.value}`)
   serperKey.value = ''
   successMessage.value = 'Serper API key cleared successfully!'
   emit('keysUpdated')
@@ -357,4 +357,4 @@ defineExpose({
     serperKey: serperKey.value
   }),
 })
-</script> 
+</script>


### PR DESCRIPTION
This PR changes:
- Access to the `userId` variable value.
  - The encrypted API keys are being saved on localStorage using the `userId` in its name, but this is creating the variables as `x_key_[object Object]` as `userId` is an object, so to access its value it's needed to use its `value` attribute. This now saves them as `x_key_user_abcd123`.