### PR TITLE
Update SemanticRouterAgent reasoning model to Llama 3.1

### DIFF
--- a/backend/api/agents/route.py
+++ b/backend/api/agents/route.py
@@ -60,7 +60,8 @@ class SemanticRouterAgent(RoutedAgent):
         logger.info(logger.format_message(None, f"Initializing SemanticRouterAgent '{name}' with ID: {self.id}"))
         self._name = name
         self._reasoning_model_client = OpenAIChatCompletionClient(
-            model="DeepSeek-R1-Distill-Llama-70B",
+            model="Meta-Llama-3.1-70B-Instruct",
+            # model="DeepSeek-R1-Distill-Llama-70B",
             base_url="https://api.sambanova.ai/v1",
             api_key=api_keys.sambanova_key,
             model_info={


### PR DESCRIPTION
- Switch default reasoning model from DeepSeek-R1-Distill-Llama-70B to Meta-Llama-3.1-70B-Instruct