### PR TITLE
Add token usage tracking to research and financial analysis crews

### DIFF
--- a/backend/agent/financial_analysis/financial_analysis_crew.py
+++ b/backend/agent/financial_analysis/financial_analysis_crew.py
@@ -2,7 +2,7 @@ import os
 import sys
 import uuid
 import json
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 import numpy as np
 import yfinance as yf
 
@@ -422,7 +422,7 @@ class FinancialAnalysisCrew:
             output_pydantic=FinancialAnalysisResult
         )
 
-    def execute_financial_analysis(self, inputs: Dict[str,Any]) -> str:
+    def execute_financial_analysis(self, inputs: Dict[str,Any]) -> Tuple[str, Dict[str,Any]]:
         """
         1) Competitor tasks => sequential
         2) Fundamentals + Technical + Risk + News => parallel
@@ -458,7 +458,7 @@ class FinancialAnalysisCrew:
             verbose=self.verbose,
         )
         final = crew.kickoff(inputs=inputs)
-        return final.pydantic.model_dump_json()
+        return final.pydantic.model_dump_json(), dict(final.token_usage)
 
 ########## EXAMPLE MAIN ##############
 def main():

--- a/backend/agent/lead_generation_crew.py
+++ b/backend/agent/lead_generation_crew.py
@@ -19,7 +19,7 @@ langtrace.init(api_key=os.getenv("LANGTRACE_API_KEY"))
 from crewai import Agent, Task, Crew, LLM, Process
 from tools.company_intelligence_tool import CompanyIntelligenceTool
 from tools.market_research_tool import MarketResearchTool
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 from pydantic import BaseModel
 from utils.agent_thought import RedisConversationLogger
 
@@ -300,7 +300,7 @@ class ResearchCrew:
             output_pydantic=OutreachList
         )
 
-    def execute_research(self, inputs: dict) -> str:
+    def execute_research(self, inputs: dict) -> Tuple[str, Dict[str,Any]]:
         """
         Run the 5-step pipeline with 4 agents in sequential order.
         """
@@ -323,7 +323,7 @@ class ResearchCrew:
             memory=False
         )
         results = crew.kickoff(inputs=inputs)
-        return results.pydantic.model_dump_json()
+        return results.pydantic.model_dump_json(), dict(results.token_usage)
 
 
 def main():
@@ -350,7 +350,7 @@ def main():
         "product": ""
     }
 
-    final_output = crew.execute_research(example_inputs)
+    final_output, _ = crew.execute_research(example_inputs)
     print("Crew Output:")
     print(final_output)
 

--- a/backend/api/agents/sales_leads.py
+++ b/backend/api/agents/sales_leads.py
@@ -39,7 +39,7 @@ class SalesLeadsAgent(RoutedAgent):
                 f"Starting lead research with parameters: {parameters_dict}"
             ))
 
-            raw_result = await asyncio.to_thread(crew.execute_research, parameters_dict)
+            raw_result, usage_stats = await asyncio.to_thread(crew.execute_research, parameters_dict)
             logger.info(logger.format_message(
                 ctx.topic_id.source,
                 "Successfully generated sales leads"
@@ -59,6 +59,7 @@ class SalesLeadsAgent(RoutedAgent):
                 agent_type=self.id.type,
                 data=outreach_list,
                 message=message.parameters.model_dump_json(),
+                metadata=usage_stats
             )
             logger.info(logger.format_message(
                 ctx.topic_id.source,

--- a/backend/api/agents/user_proxy.py
+++ b/backend/api/agents/user_proxy.py
@@ -66,9 +66,10 @@ class UserProxyAgent(RoutedAgent):
                 processing_time = None
 
             message_data = message.model_dump()
-            message_data["metadata"] = {
-                "duration": processing_time
-            }
+            # Initialize metadata if None or add duration to existing metadata
+            if message_data.get("metadata") is None:
+                message_data["metadata"] = {}
+            message_data["metadata"]["duration"] = processing_time
 
             if self.websocket:
                 message_data = {

--- a/backend/api/data_types.py
+++ b/backend/api/data_types.py
@@ -1,7 +1,7 @@
 ########## data_types.py (FULL, UNCHANGED EXCEPT NEW FIELDS) ##########
 from pydantic import BaseModel, model_validator, Field
 from enum import Enum
-from typing import List, Optional, Union, Dict
+from typing import Any, List, Optional, Union, Dict
 from datetime import date
 from agent.financial_analysis.financial_analysis_crew import FinancialAnalysisResult
 from agent.samba_research_flow.crews.edu_research.edu_research_crew import Section
@@ -151,4 +151,5 @@ class AgentStructuredResponse(BaseModel):
         UserQuestion,
         DeepResearchReport,
     ]
+    metadata: Optional[Dict[str, Any]] = None
     message: Optional[str] = None  # Additional message or notes from the agent


### PR DESCRIPTION
- Modified lead_generation_crew.py and financial_analysis_crew.py to return token usage alongside results
- Updated data_types.py to include optional metadata field in AgentStructuredResponse
- Updated agents (financial_analysis.py and sales_leads.py) to pass token usage metadata
- Updated user_proxy.py to handle metadata initialization